### PR TITLE
SHA-256 made mandatory

### DIFF
--- a/draft-ietf-mmusic-4572-update.txt
+++ b/draft-ietf-mmusic-4572-update.txt
@@ -4,9 +4,9 @@
 
 Network Working Group                                        C. Holmberg
 Internet-Draft                                                  Ericsson
-Updates: 4572 (if approved)                                 May 26, 2016
+Updates: 4572 (if approved)                                 May 27, 2016
 Intended status: Standards Track
-Expires: November 27, 2016
+Expires: November 28, 2016
 
 
                           Updates to RFC 4572
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 27, 2016.
+   This Internet-Draft will expire on November 28, 2016.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Holmberg                Expires November 27, 2016               [Page 1]
+Holmberg                Expires November 28, 2016               [Page 1]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Holmberg                Expires November 27, 2016               [Page 2]
+Holmberg                Expires November 28, 2016               [Page 2]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -165,7 +165,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-Holmberg                Expires November 27, 2016               [Page 3]
+Holmberg                Expires November 28, 2016               [Page 3]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -195,7 +195,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
     Following RFC 3279 [7] as updated by RFC 4055 [9], therefore, the
     defined hash functions are 'SHA-1' [11] [19], 'SHA-224' [11],
     'SHA-256' [11], 'SHA-384' [11], 'SHA-512' [11], 'MD5' [12], and
-    'MD2' [13]. Implementations MUST, as a minimum, calculate and
+    'MD2' [13]. Implementations SHOULD, as a minimum, calculate and
     validate a fingerprint using 'SHA-256'. A new IANA registry of Hash
     Function Textual Names, specified in Section 8, allows for addition
     of future tokens, but they may only be added if they are included
@@ -221,7 +221,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-Holmberg                Expires November 27, 2016               [Page 4]
+Holmberg                Expires November 28, 2016               [Page 4]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -237,9 +237,9 @@ Internet-Draft             Updates to RFC 4572                  May 2016
      (e.g. if separate certificates are used for RTP and RTCP), or where
      it is not known which certificate will be used when the
      fingerprints are exchanged. In such cases, one or more fingerprints
-     MUST be calculated for each possible certificate. An endpoint MUST,
-     as a minimum, calculate a fingerprint using the 'SHA-256' hash
-     function for each possible certificate.
+     MUST be calculated for each possible certificate. An endpoint
+     SHOULD, as a minimum, calculate a fingerprint using the 'SHA-256'
+     hash function for each possible certificate.
 
      If fingerprints associated with multiple certificates are
      calculated, the same set of hash functions MUST be used to
@@ -250,12 +250,13 @@ Internet-Draft             Updates to RFC 4572                  May 2016
      least one fingerprint, calculated using the hash function that the
      endpoint supports and considers most secure, with the used
      certificate. If a fingerprint calculated using the 'SHA-256' hash
-     function is present, the endpoint MUST be able to match it. If
-     there is no match, the endpoint MUST NOT establish the TLS
-     connection. In addition, the endpoint MAY also check fingerprints
-     calculated using other hash functions that it has received for a
-     match. For each hash function checked, one of the received
-     fingerprints MUST match the used certificate.
+     function is present, the endpoint SHOULD check if or a match. If
+     the checked fingerprint does not match the used certificate, the
+     endpoint MUST NOT establish the TLS connection. In addition, the
+     endpoint MAY also check fingerprints calculated using other hash
+     functions that it has received for a match. For each hash function
+     checked, one of the received fingerprints calculated using the hash
+     function MUST match the used certificate.
 
      NOTE: The SDP fingerprint attribute does not contain a reference to
      a specific certificate. Endpoints need to compare the fingerprint
@@ -276,8 +277,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-
-Holmberg                Expires November 27, 2016               [Page 5]
+Holmberg                Expires November 28, 2016               [Page 5]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -333,7 +333,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-Holmberg                Expires November 27, 2016               [Page 6]
+Holmberg                Expires November 28, 2016               [Page 6]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -389,4 +389,4 @@ Author's Address
 
 
 
-Holmberg                Expires November 27, 2016               [Page 7]
+Holmberg                Expires November 28, 2016               [Page 7]

--- a/draft-ietf-mmusic-4572-update.txt
+++ b/draft-ietf-mmusic-4572-update.txt
@@ -1,11 +1,12 @@
 
 
 
+
 Network Working Group                                        C. Holmberg
 Internet-Draft                                                  Ericsson
-Updates: 4572 (if approved)                                 May 21, 2016
+Updates: 4572 (if approved)                                 May 26, 2016
 Intended status: Standards Track
-Expires: November 22, 2016
+Expires: November 27, 2016
 
 
                           Updates to RFC 4572
@@ -15,10 +16,10 @@ Abstract
 
    This document updates RFC 4572 by clarifying the usage of multiple
    SDP 'fingerprint' attributes with a single TLS connection.  The
-   document also updates the preferred cipher suite to be used, and
-   removes the requirement to use the same hash function for calculating
-   a certificate fingerprint that is used to calculate the certificate
-   signature.
+   document also replaces the preferred cipher suite with a mandate to
+   support a stronger cipher suite, and removes the requirement to use
+   the same hash function for calculating a certificate fingerprint that
+   is used to calculate the certificate signature.
 
 Status of This Memo
 
@@ -35,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 22, 2016.
+   This Internet-Draft will expire on November 27, 2016.
 
 Copyright Notice
 
@@ -52,7 +53,7 @@ Copyright Notice
 
 
 
-Holmberg                Expires November 22, 2016               [Page 1]
+Holmberg                Expires November 27, 2016               [Page 1]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -68,7 +69,7 @@ Table of Contents
      3.1.  Update to the sixth paragraph of section 5  . . . . . . .   3
      3.2.  New paragraphs to the end of section 5  . . . . . . . . .   4
    4.  Security Considerations . . . . . . . . . . . . . . . . . . .   5
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   5
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
    6.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   6
    7.  Change Log  . . . . . . . . . . . . . . . . . . . . . . . . .   6
    8.  Normative References  . . . . . . . . . . . . . . . . . . . .   7
@@ -108,7 +109,7 @@ Table of Contents
 
 
 
-Holmberg                Expires November 22, 2016               [Page 2]
+Holmberg                Expires November 27, 2016               [Page 2]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -120,9 +121,10 @@ Internet-Draft             Updates to RFC 4572                  May 2016
    certificate, and to carry fingerprints associated with multiple
    certificates.  The fingerprint matching procedure, when multiple
    fingerprints are provided, are also clarified.  The document also
-   updates the preferred cipher suite to be used, and removes the
-   requirement to use the same hash function for calculating a
-   certificate fingerprint and certificate signature.
+   replaces the preferred cipher suite with a mandate to support a
+   stronger cipher suite, and removes the requirement to use the same
+   hash function for calculating a certificate fingerprint and
+   certificate signature.
 
 2.  Conventions
 
@@ -163,8 +165,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-
-Holmberg                Expires November 22, 2016               [Page 3]
+Holmberg                Expires November 27, 2016               [Page 3]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -194,7 +195,8 @@ Internet-Draft             Updates to RFC 4572                  May 2016
     Following RFC 3279 [7] as updated by RFC 4055 [9], therefore, the
     defined hash functions are 'SHA-1' [11] [19], 'SHA-224' [11],
     'SHA-256' [11], 'SHA-384' [11], 'SHA-512' [11], 'MD5' [12], and
-    'MD2' [13], with 'SHA-256' preferred.  A new IANA registry of Hash
+    'MD2' [13]. Implementations MUST, as a minimum, calculate and
+    validate a fingerprint using 'SHA-256'. A new IANA registry of Hash
     Function Textual Names, specified in Section 8, allows for addition
     of future tokens, but they may only be added if they are included
     in RFCs that update or obsolete RFC 3279 [7].
@@ -219,8 +221,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-
-Holmberg                Expires November 22, 2016               [Page 4]
+Holmberg                Expires November 27, 2016               [Page 4]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
@@ -236,7 +237,9 @@ Internet-Draft             Updates to RFC 4572                  May 2016
      (e.g. if separate certificates are used for RTP and RTCP), or where
      it is not known which certificate will be used when the
      fingerprints are exchanged. In such cases, one or more fingerprints
-     MUST be calculated for each possible certificate.
+     MUST be calculated for each possible certificate. An endpoint MUST,
+     as a minimum, calculate a fingerprint using the 'SHA-256' hash
+     function for each possible certificate.
 
      If fingerprints associated with multiple certificates are
      calculated, the same set of hash functions MUST be used to
@@ -246,11 +249,13 @@ Internet-Draft             Updates to RFC 4572                  May 2016
      For each used certificate, an endpoint MUST be able to match at
      least one fingerprint, calculated using the hash function that the
      endpoint supports and considers most secure, with the used
-     certificate. If there is no match, the endpoint MUST NOT establish
-     the TLS connection. In addition, the endpoint MAY also check
-     fingerprints calculated using other hash functions that it has
-     received for a match. For each hash function checked, one of the
-     received fingerprints MUST match the used certificate.
+     certificate. If a fingerprint calculated using the 'SHA-256' hash
+     function is present, the endpoint MUST be able to match it. If
+     there is no match, the endpoint MUST NOT establish the TLS
+     connection. In addition, the endpoint MAY also check fingerprints
+     calculated using other hash functions that it has received for a
+     match. For each hash function checked, one of the received
+     fingerprints MUST match the used certificate.
 
      NOTE: The SDP fingerprint attribute does not contain a reference to
      a specific certificate. Endpoints need to compare the fingerprint
@@ -265,9 +270,6 @@ Internet-Draft             Updates to RFC 4572                  May 2016
    agility, and incremental deployment of newer, and more secure, cipher
    suites.
 
-5.  IANA Considerations
-
-   This document makes no requests from IANA.
 
 
 
@@ -275,11 +277,14 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-
-Holmberg                Expires November 22, 2016               [Page 5]
+Holmberg                Expires November 27, 2016               [Page 5]
 
 Internet-Draft             Updates to RFC 4572                  May 2016
 
+
+5.  IANA Considerations
+
+   This document makes no requests from IANA.
 
 6.  Acknowledgements
 
@@ -291,6 +296,9 @@ Internet-Draft             Updates to RFC 4572                  May 2016
    [RFC EDITOR NOTE: Please remove this section when publishing]
 
    Changes from draft-ietf-mmusic-4572-update-02
+
+   o  Mandatory to provide and validate fingerprint calculated using
+      SHA-256.
 
    o  Editorial fixes based on comments from Martin Thomson.
 
@@ -322,20 +330,19 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
    o  - Additional text added to security considerations section.
 
+
+
+
+Holmberg                Expires November 27, 2016               [Page 6]
+
+Internet-Draft             Updates to RFC 4572                  May 2016
+
+
    Changes from draft-holmberg-mmusic-4572-update-01
 
    o  Adopted WG document (draft-ietf-mmusic-4572-update-00) submitted.
 
    o  IANA considerations section added.
-
-
-
-
-
-Holmberg                Expires November 22, 2016               [Page 6]
-
-Internet-Draft             Updates to RFC 4572                  May 2016
-
 
 8.  Normative References
 
@@ -382,10 +389,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-Holmberg                Expires November 22, 2016               [Page 7]
+Holmberg                Expires November 27, 2016               [Page 7]

--- a/draft-ietf-mmusic-4572-update.txt
+++ b/draft-ietf-mmusic-4572-update.txt
@@ -4,9 +4,9 @@
 
 Network Working Group                                        C. Holmberg
 Internet-Draft                                                  Ericsson
-Updates: 4572 (if approved)                                 May 27, 2016
+Updates: 4572 (if approved)                                 June 1, 2016
 Intended status: Standards Track
-Expires: November 28, 2016
+Expires: December 3, 2016
 
 
                           Updates to RFC 4572
@@ -16,10 +16,10 @@ Abstract
 
    This document updates RFC 4572 by clarifying the usage of multiple
    SDP 'fingerprint' attributes with a single TLS connection.  The
-   document also replaces the preferred cipher suite with a mandate to
-   support a stronger cipher suite, and removes the requirement to use
-   the same hash function for calculating a certificate fingerprint that
-   is used to calculate the certificate signature.
+   document also updates the preferred cipher suite with a stronger
+   cipher suite, and removes the requirement to use the same hash
+   function for calculating a certificate fingerprint that is used to
+   calculate the certificate signature.
 
 Status of This Memo
 
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on November 28, 2016.
+   This Internet-Draft will expire on December 3, 2016.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Holmberg                Expires November 28, 2016               [Page 1]
+Holmberg                Expires December 3, 2016                [Page 1]
 
-Internet-Draft             Updates to RFC 4572                  May 2016
+Internet-Draft             Updates to RFC 4572                 June 2016
 
 
    the Trust Legal Provisions and are provided without warranty as
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Holmberg                Expires November 28, 2016               [Page 2]
+Holmberg                Expires December 3, 2016                [Page 2]
 
-Internet-Draft             Updates to RFC 4572                  May 2016
+Internet-Draft             Updates to RFC 4572                 June 2016
 
 
    This document updates RFC 4572 [RFC4572] by clarifying the usage of
@@ -121,10 +121,9 @@ Internet-Draft             Updates to RFC 4572                  May 2016
    certificate, and to carry fingerprints associated with multiple
    certificates.  The fingerprint matching procedure, when multiple
    fingerprints are provided, are also clarified.  The document also
-   replaces the preferred cipher suite with a mandate to support a
-   stronger cipher suite, and removes the requirement to use the same
-   hash function for calculating a certificate fingerprint and
-   certificate signature.
+   updates the preferred cipher suite with a stronger cipher suite, and
+   removes the requirement to use the same hash function for calculating
+   a certificate fingerprint and certificate signature.
 
 2.  Conventions
 
@@ -165,9 +164,10 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-Holmberg                Expires November 28, 2016               [Page 3]
+
+Holmberg                Expires December 3, 2016                [Page 3]
 
-Internet-Draft             Updates to RFC 4572                  May 2016
+Internet-Draft             Updates to RFC 4572                 June 2016
 
 
  OLD TEXT:
@@ -195,8 +195,7 @@ Internet-Draft             Updates to RFC 4572                  May 2016
     Following RFC 3279 [7] as updated by RFC 4055 [9], therefore, the
     defined hash functions are 'SHA-1' [11] [19], 'SHA-224' [11],
     'SHA-256' [11], 'SHA-384' [11], 'SHA-512' [11], 'MD5' [12], and
-    'MD2' [13]. Implementations SHOULD, as a minimum, calculate and
-    validate a fingerprint using 'SHA-256'. A new IANA registry of Hash
+    'MD2' [13], with 'SHA-256' preferred. A new IANA registry of Hash
     Function Textual Names, specified in Section 8, allows for addition
     of future tokens, but they may only be added if they are included
     in RFCs that update or obsolete RFC 3279 [7].
@@ -221,9 +220,10 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-Holmberg                Expires November 28, 2016               [Page 4]
+
+Holmberg                Expires December 3, 2016                [Page 4]
 
-Internet-Draft             Updates to RFC 4572                  May 2016
+Internet-Draft             Updates to RFC 4572                 June 2016
 
 
  NEW TEXT:
@@ -238,8 +238,13 @@ Internet-Draft             Updates to RFC 4572                  May 2016
      it is not known which certificate will be used when the
      fingerprints are exchanged. In such cases, one or more fingerprints
      MUST be calculated for each possible certificate. An endpoint
-     SHOULD, as a minimum, calculate a fingerprint using the 'SHA-256'
-     hash function for each possible certificate.
+     MUST, as a minimum, calculate a fingerprint using the 'SHA-256'
+     hash function algorithm for each possible certificate, unless the
+     endpoint knows that the peer supports a stronger algorithm, or
+     unless the endpoint knows that the peer has not been upgraded to
+     support the 'SHA-256' algorithm, or unless the endpoint is used for
+     a service, or within an environment that mandates usage of a
+     stronger algorithm.
 
      If fingerprints associated with multiple certificates are
      calculated, the same set of hash functions MUST be used to
@@ -249,14 +254,12 @@ Internet-Draft             Updates to RFC 4572                  May 2016
      For each used certificate, an endpoint MUST be able to match at
      least one fingerprint, calculated using the hash function that the
      endpoint supports and considers most secure, with the used
-     certificate. If a fingerprint calculated using the 'SHA-256' hash
-     function is present, the endpoint SHOULD check if or a match. If
-     the checked fingerprint does not match the used certificate, the
-     endpoint MUST NOT establish the TLS connection. In addition, the
-     endpoint MAY also check fingerprints calculated using other hash
-     functions that it has received for a match. For each hash function
-     checked, one of the received fingerprints calculated using the hash
-     function MUST match the used certificate.
+     certificate. If the checked fingerprint does not match the used
+     certificate, the endpoint MUST NOT establish the TLS connection. In
+     addition, the endpoint MAY also check fingerprints calculated using
+     other hash functions that it has received for a match. For each
+     hash function checked, one of the received fingerprints calculated
+     using the hash function MUST match the used certificate.
 
      NOTE: The SDP fingerprint attribute does not contain a reference to
      a specific certificate. Endpoints need to compare the fingerprint
@@ -274,12 +277,9 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-
-
-
-Holmberg                Expires November 28, 2016               [Page 5]
+Holmberg                Expires December 3, 2016                [Page 5]
 
-Internet-Draft             Updates to RFC 4572                  May 2016
+Internet-Draft             Updates to RFC 4572                 June 2016
 
 
 5.  IANA Considerations
@@ -333,9 +333,9 @@ Internet-Draft             Updates to RFC 4572                  May 2016
 
 
 
-Holmberg                Expires November 28, 2016               [Page 6]
+Holmberg                Expires December 3, 2016                [Page 6]
 
-Internet-Draft             Updates to RFC 4572                  May 2016
+Internet-Draft             Updates to RFC 4572                 June 2016
 
 
    Changes from draft-holmberg-mmusic-4572-update-01
@@ -389,4 +389,4 @@ Author's Address
 
 
 
-Holmberg                Expires November 28, 2016               [Page 7]
+Holmberg                Expires December 3, 2016                [Page 7]

--- a/draft-ietf-mmusic-4572-update.xml
+++ b/draft-ietf-mmusic-4572-update.xml
@@ -29,10 +29,10 @@
     <abstract>
 		<t>
             This document updates RFC 4572 by clarifying the usage of multiple SDP 'fingerprint'
-            attributes with a single TLS connection. The document also replaces the preferred cipher
-            suite with a mandate to support a stronger cipher suite, and removes the requirement to
-            use the same hash function for calculating a certificate fingerprint that is used to
-            calculate the certificate signature.
+            attributes with a single TLS connection. The document also updates the preferred cipher
+            suite with a stronger cipher suite, and removes the requirement to use the same hash
+            function for calculating a certificate fingerprint that is used to calculate the
+            certificate signature.
         </t>
     </abstract>
 </front>
@@ -72,10 +72,9 @@
             multiple 'fingerprint' attributes can be used to carry fingerprints, calculated using
             different hash functions, associated with a given certificate, and to carry fingerprints
             associated with multiple certificates. The fingerprint matching procedure, when multiple
-            fingerprints are provided, are also clarified. The document also replaces the preferred
-            cipher suite with a mandate to support a stronger cipher suite, and removes the requirement
-            to use the same hash function for calculating a certificate fingerprint and certificate
-            signature.
+            fingerprints are provided, are also clarified. The document also updates the preferred
+            cipher suite with a stronger cipher suite, and removes the requirement to use the same
+            hash function for calculating a certificate fingerprint and certificate signature.
         </t>
     </section>
 
@@ -120,8 +119,7 @@ NEW TEXT:
    Following RFC 3279 [7] as updated by RFC 4055 [9], therefore, the
    defined hash functions are 'SHA-1' [11] [19], 'SHA-224' [11],
    'SHA-256' [11], 'SHA-384' [11], 'SHA-512' [11], 'MD5' [12], and
-   'MD2' [13]. Implementations SHOULD, as a minimum, calculate and
-   validate a fingerprint using 'SHA-256'. A new IANA registry of Hash
+   'MD2' [13], with 'SHA-256' preferred. A new IANA registry of Hash
    Function Textual Names, specified in Section 8, allows for addition
    of future tokens, but they may only be added if they are included
    in RFCs that update or obsolete RFC 3279 [7].
@@ -146,8 +144,13 @@ NEW TEXT:
     it is not known which certificate will be used when the
     fingerprints are exchanged. In such cases, one or more fingerprints
     MUST be calculated for each possible certificate. An endpoint
-    SHOULD, as a minimum, calculate a fingerprint using the 'SHA-256'
-    hash function for each possible certificate.
+    MUST, as a minimum, calculate a fingerprint using the 'SHA-256'
+    hash function algorithm for each possible certificate, unless the
+    endpoint knows that the peer supports a stronger algorithm, or
+    unless the endpoint knows that the peer has not been upgraded to
+    support the 'SHA-256' algorithm, or unless the endpoint is used for
+    a service, or within an environment that mandates usage of a
+    stronger algorithm.
 
     If fingerprints associated with multiple certificates are
     calculated, the same set of hash functions MUST be used to
@@ -157,14 +160,12 @@ NEW TEXT:
     For each used certificate, an endpoint MUST be able to match at
     least one fingerprint, calculated using the hash function that the
     endpoint supports and considers most secure, with the used
-    certificate. If a fingerprint calculated using the 'SHA-256' hash
-    function is present, the endpoint SHOULD check if or a match. If
-    the checked fingerprint does not match the used certificate, the
-    endpoint MUST NOT establish the TLS connection. In addition, the
-    endpoint MAY also check fingerprints calculated using other hash
-    functions that it has received for a match. For each hash function
-    checked, one of the received fingerprints calculated using the hash
-    function MUST match the used certificate.
+    certificate. If the checked fingerprint does not match the used
+    certificate, the endpoint MUST NOT establish the TLS connection. In
+    addition, the endpoint MAY also check fingerprints calculated using
+    other hash functions that it has received for a match. For each
+    hash function checked, one of the received fingerprints calculated
+    using the hash function MUST match the used certificate.
 
     NOTE: The SDP fingerprint attribute does not contain a reference to
     a specific certificate. Endpoints need to compare the fingerprint

--- a/draft-ietf-mmusic-4572-update.xml
+++ b/draft-ietf-mmusic-4572-update.xml
@@ -120,7 +120,7 @@ NEW TEXT:
    Following RFC 3279 [7] as updated by RFC 4055 [9], therefore, the
    defined hash functions are 'SHA-1' [11] [19], 'SHA-224' [11],
    'SHA-256' [11], 'SHA-384' [11], 'SHA-512' [11], 'MD5' [12], and
-   'MD2' [13]. Implementations MUST, as a minimum, calculate and
+   'MD2' [13]. Implementations SHOULD, as a minimum, calculate and
    validate a fingerprint using 'SHA-256'. A new IANA registry of Hash
    Function Textual Names, specified in Section 8, allows for addition
    of future tokens, but they may only be added if they are included
@@ -145,9 +145,9 @@ NEW TEXT:
     (e.g. if separate certificates are used for RTP and RTCP), or where
     it is not known which certificate will be used when the
     fingerprints are exchanged. In such cases, one or more fingerprints
-    MUST be calculated for each possible certificate. An endpoint MUST,
-    as a minimum, calculate a fingerprint using the 'SHA-256' hash
-    function for each possible certificate.
+    MUST be calculated for each possible certificate. An endpoint
+    SHOULD, as a minimum, calculate a fingerprint using the 'SHA-256'
+    hash function for each possible certificate.
 
     If fingerprints associated with multiple certificates are
     calculated, the same set of hash functions MUST be used to
@@ -158,12 +158,13 @@ NEW TEXT:
     least one fingerprint, calculated using the hash function that the
     endpoint supports and considers most secure, with the used
     certificate. If a fingerprint calculated using the 'SHA-256' hash
-    function is present, the endpoint MUST be able to match it. If
-    there is no match, the endpoint MUST NOT establish the TLS
-    connection. In addition, the endpoint MAY also check fingerprints
-    calculated using other hash functions that it has received for a
-    match. For each hash function checked, one of the received
-    fingerprints MUST match the used certificate.
+    function is present, the endpoint SHOULD check if or a match. If
+    the checked fingerprint does not match the used certificate, the
+    endpoint MUST NOT establish the TLS connection. In addition, the
+    endpoint MAY also check fingerprints calculated using other hash
+    functions that it has received for a match. For each hash function
+    checked, one of the received fingerprints calculated using the hash
+    function MUST match the used certificate.
 
     NOTE: The SDP fingerprint attribute does not contain a reference to
     a specific certificate. Endpoints need to compare the fingerprint

--- a/draft-ietf-mmusic-4572-update.xml
+++ b/draft-ietf-mmusic-4572-update.xml
@@ -29,10 +29,10 @@
     <abstract>
 		<t>
             This document updates RFC 4572 by clarifying the usage of multiple SDP 'fingerprint'
-            attributes with a single TLS connection. The document also updates the preferred
-            cipher suite to be used, and removes the requirement to use the same hash function
-            for calculating a certificate fingerprint that is used to calculate the
-            certificate signature.
+            attributes with a single TLS connection. The document also replaces the preferred cipher
+            suite with a mandate to support a stronger cipher suite, and removes the requirement to
+            use the same hash function for calculating a certificate fingerprint that is used to
+            calculate the certificate signature.
         </t>
     </abstract>
 </front>
@@ -50,7 +50,7 @@
             multiple 'fingerprint' attributes can be associated with a single SDP media description ("m= line")
             <xref format="default" pageno="false" target="RFC4566"/>, and the associated semantics.
             Multiple fingerprints are needed if an endpoints wants to provide fingerprints associated with
-            multiple certificates. For example, with RTP-based media, an endpoint might use different 
+            multiple certificates. For example, with RTP-based media, an endpoint might use different
             certificates for RTP and RTCP.
         </t>
         <t>
@@ -72,9 +72,10 @@
             multiple 'fingerprint' attributes can be used to carry fingerprints, calculated using
             different hash functions, associated with a given certificate, and to carry fingerprints
             associated with multiple certificates. The fingerprint matching procedure, when multiple
-            fingerprints are provided, are also clarified. The document also updates the preferred 
-            cipher suite to be used, and removes the requirement to use the same hash function for 
-            calculating a certificate fingerprint and certificate signature.
+            fingerprints are provided, are also clarified. The document also replaces the preferred
+            cipher suite with a mandate to support a stronger cipher suite, and removes the requirement
+            to use the same hash function for calculating a certificate fingerprint and certificate
+            signature.
         </t>
     </section>
 
@@ -85,7 +86,7 @@
 			document are to be interpreted as described in <xref target="RFC2119"></xref>.
 		</t>
     </section>
-     
+
     <section title="Update to RFC 4572">
         <t>
             This section updates section 5 of RFC 4572.
@@ -119,7 +120,8 @@ NEW TEXT:
    Following RFC 3279 [7] as updated by RFC 4055 [9], therefore, the
    defined hash functions are 'SHA-1' [11] [19], 'SHA-224' [11],
    'SHA-256' [11], 'SHA-384' [11], 'SHA-512' [11], 'MD5' [12], and
-   'MD2' [13], with 'SHA-256' preferred.  A new IANA registry of Hash
+   'MD2' [13]. Implementations MUST, as a minimum, calculate and
+   validate a fingerprint using 'SHA-256'. A new IANA registry of Hash
    Function Textual Names, specified in Section 8, allows for addition
    of future tokens, but they may only be added if they are included
    in RFCs that update or obsolete RFC 3279 [7].
@@ -134,31 +136,35 @@ NEW TEXT:
 
 NEW TEXT:
 
-    Multiple SDP fingerprint attributes can be associated with an m- 
+    Multiple SDP fingerprint attributes can be associated with an m-
     line. This can occur if multiple fingerprints have been calculated
     for a certificate using different hash functions. It can also
-    occur if one or more fingerprints associated with multiple 
+    occur if one or more fingerprints associated with multiple
     certificates have been calculated. This might be needed if multiple
-    certificates will be used for media associated with an m- line 
+    certificates will be used for media associated with an m- line
     (e.g. if separate certificates are used for RTP and RTCP), or where
-    it is not known which certificate will be used when the 
+    it is not known which certificate will be used when the
     fingerprints are exchanged. In such cases, one or more fingerprints
-    MUST be calculated for each possible certificate.
-        
-    If fingerprints associated with multiple certificates are 
+    MUST be calculated for each possible certificate. An endpoint MUST,
+    as a minimum, calculate a fingerprint using the 'SHA-256' hash
+    function for each possible certificate.
+
+    If fingerprints associated with multiple certificates are
     calculated, the same set of hash functions MUST be used to
     calculate fingerprints for each certificate associated with the
     m- line.
-        
+
     For each used certificate, an endpoint MUST be able to match at
     least one fingerprint, calculated using the hash function that the
     endpoint supports and considers most secure, with the used
-    certificate. If there is no match, the endpoint MUST NOT establish
-    the TLS connection. In addition, the endpoint MAY also check 
-    fingerprints calculated using other hash functions that it has
-    received for a match. For each hash function checked, one of the
-    received fingerprints MUST match the used certificate.
-    
+    certificate. If a fingerprint calculated using the 'SHA-256' hash
+    function is present, the endpoint MUST be able to match it. If
+    there is no match, the endpoint MUST NOT establish the TLS
+    connection. In addition, the endpoint MAY also check fingerprints
+    calculated using other hash functions that it has received for a
+    match. For each hash function checked, one of the received
+    fingerprints MUST match the used certificate.
+
     NOTE: The SDP fingerprint attribute does not contain a reference to
     a specific certificate. Endpoints need to compare the fingerprint
     with a certificate hash in order to look for a match.
@@ -194,6 +200,7 @@ NEW TEXT:
 		<t>[RFC EDITOR NOTE: Please remove this section when publishing]</t>
             <t>Changes from draft-ietf-mmusic-4572-update-02
                 <list style="symbols">
+                    <t>Mandatory to provide and validate fingerprint calculated using SHA-256.</t>
                     <t>Editorial fixes based on comments from Martin Thomson.</t>
                     <t>Non-used references removed.</t>
                 </list>


### PR DESCRIPTION
The change makes it mandatory for endpoints to provide and validate fingerprints calculated using the SHA-256 hash algorithm.
