### PR TITLE
Corrects minor factual mismatches in document abstract

### DIFF
--- a/draft-ietf-mmusic-4572-update.xml
+++ b/draft-ietf-mmusic-4572-update.xml
@@ -29,8 +29,8 @@
     <abstract>
 		<t>
             This document updates RFC 4572 by clarifying the usage of multiple SDP 'fingerprint'
-            attributes with a single TLS connection. The document also updates the preferred cipher
-            suite with a stronger cipher suite, and removes the requirement to use the same hash
+            attributes with a single SDP media description ("m= line"). The document also updates the preferred cipher
+            suite with a stronger cipher suite, and removes the requirement to only use the same hash
             function for calculating a certificate fingerprint that is used to calculate the
             certificate signature.
         </t>

--- a/draft-ietf-mmusic-4572-update.xml
+++ b/draft-ietf-mmusic-4572-update.xml
@@ -30,9 +30,7 @@
 		<t>
             This document updates RFC 4572 by clarifying the usage of multiple SDP 'fingerprint'
             attributes with a single SDP media description ("m= line"). The document also updates the preferred cipher
-            suite with a stronger cipher suite, and removes the requirement to only use the same hash
-            function for calculating a certificate fingerprint that is used to calculate the
-            certificate signature.
+            suite with a stronger cipher suite.
         </t>
     </abstract>
 </front>


### PR DESCRIPTION
Updates the document abstract to match current document

Replaces single TLS connection with single m= line
Clarifies that document allows other hash functions in addition to hash used to sign the certificate even though hash function used to sign the certificate is still required
